### PR TITLE
Added postcss-modules-local-by-default dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "extract-text-webpack-plugin": "^0.8.1",
     "node-libs-browser": "^0.5.2",
     "postcss-loader": "^0.4.4",
+    "postcss-modules-local-by-default":  "^v0.0.10",
     "style-loader": "^0.12.3",
     "webpack": "^1.9.10"
   },


### PR DESCRIPTION
I was getting webpack issues: Error: Cannot find module 'postcss-modules-local-by-default', so I added that dependency to the root package.json file.